### PR TITLE
[SAS-9509] add backfill, enddate

### DIFF
--- a/README/inputs.conf.spec
+++ b/README/inputs.conf.spec
@@ -4,6 +4,7 @@
 message_limit = <value>
 duration = <value>
 initial_start_date = <value>
+end_date = <value>
 client_id = <value>
 client_secret = <value>
 cisco_token_host = <value>

--- a/bin/cisco_helper/cisco_client.py
+++ b/bin/cisco_helper/cisco_client.py
@@ -15,6 +15,7 @@ class CiscoClient(object):
         self._client_id = configs['client_id']
         self._cisco_token_host = configs['cisco_token_host']
         self._cisco_service_host = configs['cisco_service_host']
+        self._end_date = configs['end_date'] 
         self._secret = configs['client_secret']
         self._token = self.get_token()
 
@@ -94,9 +95,10 @@ class CiscoClient(object):
         start_time = initial_time.isoformat()
         end_time = (datetime.utcnow() - timedelta(minutes=self._duration)).isoformat()
         # cisco api only limits time range to two months, if time range is wider than 30 days
-        # change the end time to current time + 30 days
-        if (datetime.utcnow() - initial_time).days > 30:
-            # just add 30 days at a time
-            end_time = (initial_time + timedelta(days=30)).isoformat()
-
-        return start_time, end_time
+        # change the end time to current time + 5 minutes
+        while initial_time <  datetime.strptime(self._end_date,'%Y-%m-%dT%H:%M:%S+00:00'):
+          #datetime.strptime('2024/03/14:18:00:00','%Y/%m/%d:%H:%M:%S'):
+          if (datetime.utcnow() - initial_time) > timedelta(seconds=300):
+              # just add 5 minutes (300 seconds) at a time
+              end_time = (initial_time + timedelta(seconds=300)).isoformat()
+          return start_time, end_time

--- a/bin/cisco_phishing_input.py
+++ b/bin/cisco_phishing_input.py
@@ -71,6 +71,17 @@ class CiscoPhishingInput(Script):
         )
         scheme.add_argument(start_date_arg)
 
+        end_date_arg = Argument(
+            name='end_date',
+            title='End Date',
+            description='The end point of fetching data (use to backfill)',
+            data_type=Argument.data_type_string,
+            required_on_create=False,
+            required_on_edit=False
+        )
+        scheme.add_argument(end_date_arg)
+
+
         client_id_arg = Argument(
             name='client_id',
             title='Client Id',
@@ -152,6 +163,12 @@ class CiscoPhishingInput(Script):
         except:
             raise ValueError(
                 "Invalid initial start date value, please use the following format 'yyyy-mm-ddThh:mm:ss+00:00'")
+        try:
+            end_date = datetime.strptime(validation_definition.parameters["end_date"],
+                                                   '%Y-%m-%dT%H:%M:%S+00:00')
+        except:
+            raise ValueError(
+                "Invalid end date value, please use the following format 'yyyy-mm-ddThh:mm:ss+00:00'")
 
     def stream_events(self, inputs, ew):
         """This function handles all the action: splunk calls this modular input
@@ -177,6 +194,9 @@ class CiscoPhishingInput(Script):
                 masked_secret = input_item['client_secret']
                 initial_start_date = datetime.strptime(input_item["initial_start_date"],
                                                        '%Y-%m-%dT%H:%M:%S+00:00')
+                end_date = datetime.strptime(input_item["end_date"],
+                                                       '%Y-%m-%dT%H:%M:%S+00:00')
+
 
                 config_provider = data_encryption.DataEncryption(session_key, input_name)
                 # get the real secret from splunk client
@@ -186,6 +206,7 @@ class CiscoPhishingInput(Script):
                     'duration': input_item['duration'],
                     'message_limit': input_item['message_limit'],
                     'initial_start_date': input_item['initial_start_date'],
+                    'end_date': input_item['end_date'],
                     'cisco_token_host': input_item['cisco_token_host'],
                     'cisco_service_host': input_item['cisco_service_host']
                 }

--- a/default/inputs.conf
+++ b/default/inputs.conf
@@ -5,5 +5,6 @@ message_limit = 1000
 interval    = 60
 duration = 5
 initial_start_date = 2022-04-01T00:00:00+00:00
+end_date           = 2024-03-14T18:00:00+00:00
 cisco_token_host = api.dmp.cisco.com
 cisco_service_host = api.appc.cisco.com


### PR DESCRIPTION
Creates end_date field field inputs.conf for use in backfill situations
Updates the url string end_time in bin/cisco_helper/cisco_client.py to be 5 minutes beyond the start time of the call. This value is hardcoded. The prior value allowed 30 days beyond the current time. The cisco_phishing api was not able to gather the quantity of events available, so we reduced the period to a value that worked during testing.
The end_time field in inputs.conf is an upper limit date and time. Once the current time is greater than the end_time value, the app will stop collecting new events. We assume the user has ingested data is more recent than the end_time. 